### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the alias to `app/config/app.php`:
 ```php
     'aliases' => array(
         // ...
-        'OpenGraph' => 'Chriskonnertz\\OpenGraph\\OpenGraph',
+        'OpenGraph' => 'ChrisKonnertz\\OpenGraph\\OpenGraph',
     )
 ```
 


### PR DESCRIPTION
Fixing a Spelling Error in "
 'OpenGraph' => 'Chriskonnertz\OpenGraph\OpenGraph',
".

Changed to:
        'OpenGraph' => 'ChrisKonnertz\OpenGraph\OpenGraph',
