### PR TITLE
Prevent XSS by stripping tags from $_SERVER['REQUEST_URI'].

### DIFF
--- a/src/ChrisKonnertz/OpenGraph/OpenGraph.php
+++ b/src/ChrisKonnertz/OpenGraph/OpenGraph.php
@@ -331,8 +331,11 @@ class OpenGraph {
             if (isset($_SERVER['HTTPS'])) {
                 $url .= 's';
             }
+            
+            $safeRequestURI = htmlentities(strip_tags(urldecode($_SERVER['REQUEST_URI'])));
+            $safeRequestURI = preg_replace('/alert|log/is','',$safeRequestURI);
 
-            $url .= "://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+            $url .= "://{$_SERVER['HTTP_HOST']}{$safeRequestURI}";
         } 
 
         if ($this->validate and ! filter_var($url, FILTER_VALIDATE_URL)) {

--- a/src/ChrisKonnertz/OpenGraph/OpenGraph.php
+++ b/src/ChrisKonnertz/OpenGraph/OpenGraph.php
@@ -333,7 +333,6 @@ class OpenGraph {
             }
             
             $safeRequestURI = htmlentities(strip_tags(urldecode($_SERVER['REQUEST_URI'])));
-            $safeRequestURI = preg_replace('/alert|log/is','',$safeRequestURI);
 
             $url .= "://{$_SERVER['HTTP_HOST']}{$safeRequestURI}";
         } 


### PR DESCRIPTION
 When $og->url() is called, without a parameter, tags can be injected into the page where the og tags are rendered. Here's an example of how it can be done: 
 `http://example.com/?"><script>alert(1234)</script>`