### PR TITLE
function localeAlternate passing only one value

### DIFF
--- a/src/ChrisKonnertz/OpenGraph/OpenGraph.php
+++ b/src/ChrisKonnertz/OpenGraph/OpenGraph.php
@@ -393,6 +393,9 @@ class OpenGraph
      */
     public function localeAlternate($locales = array())
     {
+        if(is_string($locales))
+            $locales = (array) $locales;
+        
         foreach ($locales as $key => $locale) {
             if ($this->validate and ! $locale) {
                 throw new Exception("Open Graph: Invalid locale (item key: {$key})");


### PR DESCRIPTION
If the function wants a string array mandatory, make the parameter $locales typed array