### PR TITLE
Fixed: attributesstring to attributes

### DIFF
--- a/src/ChrisKonnertz/OpenGraph/OpenGraph.php
+++ b/src/ChrisKonnertz/OpenGraph/OpenGraph.php
@@ -173,7 +173,7 @@ class OpenGraph
      * @param bool     $prefixed   Add the "og"-prefix?
      * @return OpenGraph
      */
-    public function attributesstring (
+    public function attributes (
         string $tagName, 
         array $attributes = [], 
         array $valid = [], 


### PR DESCRIPTION
I have changed function names due to this error, 

https://github.com/chriskonnertz/open-graph/issues/30

After changing the function name to `attributes` issue was solved